### PR TITLE
Update docksal.yml

### DIFF
--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -7,7 +7,7 @@ services:
   web:
     extends:
       file: ${HOME}/.docksal/stacks/services.yml
-      service: web
+      service: apache
     depends_on:
       - cli
 


### PR DESCRIPTION
Change service name web => apache

Modifying service name in docksal.yml to match the service name in service.yml "apache" (originally "web") after docksal upgrading.

Or else it will spit out error message not finding service name "web"